### PR TITLE
add support for direct folder input and multiple input paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Extract version from main.go
         id: version
         run: |
-          VER=$(grep -Eo 'VERSION\s*=\s*"v[0-9]+\.[0-9]+\.[0-9]+"' main.go | sed 's/.*="//; s/"//')
+          VER=$(sed -n 's/^const VERSION = "\(v[0-9]*\.[0-9]*\.[0-9]*\)".*$/\1/p' main.go)
           echo "ver=$VER" >> $GITHUB_OUTPUT
 
       - name: Get commit message

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module convert_cbz
 
 go 1.24.5
+
+require github.com/jelius-sama/logger v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jelius-sama/logger v1.0.2 h1:Ol49Fep5TV3E/ZyIwEGo+KHpUisFQlu4Pgk07eeNEVc=
+github.com/jelius-sama/logger v1.0.2/go.mod h1:KoOqIZzGX+t5q3qoDaiXA70Grpc1E1xixyE8T9r+i/M=


### PR DESCRIPTION
- Add -recursive flag to control directory scanning behavior
- Support multiple -input flags for processing multiple directories
- Default to direct mode (convert specified folders only)
- Recursive mode (-recursive) maintains original batch processing behavior
- Implement duplicate path detection to prevent redundant processing
- Update help text and examples for new usage patterns

Breaking change: -input now requires explicit flag specification
instead of being a positional argument. For batch processing of
subdirectories, use -recursive flag.